### PR TITLE
fix:yaw角の範囲を-3.14[rad]から3.14[rad]にする

### DIFF
--- a/wit_driver/src/wit_driver.cpp
+++ b/wit_driver/src/wit_driver.cpp
@@ -186,6 +186,8 @@ void WitDriver::spin() {
         if (flag == Data::Flags::RPY) {
           if (isnan(yaw_offset_)) yaw_offset_ = data_.imugps_.rpy[2];
           relate_yaw_ = data_.imugps_.rpy[2] - yaw_offset_;
+          while (relate_yaw_ > M_PI) relate_yaw_ -= 2 * M_PI;
+          while (relate_yaw_ < -M_PI) relate_yaw_ += 2 * M_PI;
         }
       }
       unlockDataAccess();


### PR DESCRIPTION
**/resetYawOffset**をPublishすることで任意のタイミングでYaw角のオフセットができる利点があるものの、これによってyaw角の範囲が-3.14[rad]から3.14[rad]から外れてしまいます。ですので、範囲が外れた時に正規化を行って範囲に収まるようにすることで汎用性が高くなると思います。